### PR TITLE
Fix utils namespacing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,5 +36,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
       - name: Install dependencies
         run: bundle install
+      - name: Run rubocop
+        run: bundle exec rubocop
       - name: Run tests
-        run: bundle exec rake
+        run: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For ActiveJob, enqueing is being done calling the very own `perform_later` insta
 
 * Open Sidekiq Web, click the `Enqueuer` tab.
 
-* You can see a list of job classes/modules and params. Click Enqueue Form.
+* You can see a list of job classes/modules and params. Click Enqueue.
 
 ![list](https://cloud.githubusercontent.com/assets/830633/14494297/c9b01b10-01bc-11e6-8ef5-a4d29ff45fb3.png)
 

--- a/lib/sidekiq/enqueuer.rb
+++ b/lib/sidekiq/enqueuer.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 require "sidekiq/web"
-require "sidekiq/enqueuer/version"
 require "sidekiq/enqueuer/configuration"
+require "sidekiq/enqueuer/utils"
+require "sidekiq/enqueuer/version"
 require "sidekiq/enqueuer/worker/instance"
 require "sidekiq/enqueuer/worker/param"
 require "sidekiq/enqueuer/worker/trigger"
-require "sidekiq/enqueuer/web_extension/loader"
 require "sidekiq/enqueuer/web_extension/helper"
+require "sidekiq/enqueuer/web_extension/loader"
 require "sidekiq/enqueuer/web_extension/params_parser"
 
 module Sidekiq

--- a/lib/sidekiq/enqueuer/configuration.rb
+++ b/lib/sidekiq/enqueuer/configuration.rb
@@ -53,11 +53,15 @@ module Sidekiq
       end
 
       def sidekiq_jobs
-        ObjectSpace.each_object(Class).select { |job| Sidekiq::Enqueuer::Utils.sidekiq_job?(job) }
+        ObjectSpace.each_object(Class).select do |job|
+          ::Sidekiq::Enqueuer::Utils.sidekiq_job?(job)
+        end
       end
 
       def active_jobs
-        ObjectSpace.each_object(Class).select { |job| Sidekiq::Enqueuer::Utils.active_job?(job) }
+        ObjectSpace.each_object(Class).select do |job|
+          ::Sidekiq::Enqueuer::Utils.active_job?(job)
+        end
       end
 
       # Load all classes from the included application before selecting Jobs from it

--- a/lib/sidekiq/enqueuer/configuration.rb
+++ b/lib/sidekiq/enqueuer/configuration.rb
@@ -7,11 +7,11 @@ module Sidekiq
 
       attr_accessor :jobs, :async
 
-      IGNORED_CLASSES = %w[Sidekiq::Extensions
-                           Sidekiq::Extensions::DelayedModel
+      IGNORED_CLASSES = %w[Sidekiq::Extensions::DelayedModel
                            Sidekiq::Extensions::DelayedMailer
                            Sidekiq::Extensions::DelayedClass
-                           ActiveJob::QueueAdapters].freeze
+                           ApplicationJob
+                           ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper].freeze
 
       def initialize(async: true)
         @async = async

--- a/lib/sidekiq/enqueuer/utils.rb
+++ b/lib/sidekiq/enqueuer/utils.rb
@@ -6,7 +6,9 @@ module Sidekiq
       extend self
 
       def active_job?(job_class)
-        job_class <= ::ActiveJob::Base
+        return false if job_class.singleton_class?
+
+        job_class < ::ActiveJob::Base
       end
 
       def sidekiq_job?(job_class)

--- a/lib/sidekiq/enqueuer/views/index.erb
+++ b/lib/sidekiq/enqueuer/views/index.erb
@@ -15,7 +15,7 @@
         <td width="40%"><%= job.params.map(&:name).join(', ') %></td>
         <td width="20%">
           <a class="btn btn-danger btn-xs" href="<%= root_path %>enqueuer/<%= job.name %>" style="color: white;">
-            Enqueue Form
+            Enqueue
           </a>
         </td>
       </tr>

--- a/lib/sidekiq/enqueuer/web_extension/loader.rb
+++ b/lib/sidekiq/enqueuer/web_extension/loader.rb
@@ -36,7 +36,7 @@ module Sidekiq
               end
             end
 
-            redirect File.join(root_path, enqueuer)
+            redirect File.join(root_path, "enqueuer")
           end
         end
         # rubocop:enable Metrics/MethodLength

--- a/lib/sidekiq/enqueuer/web_extension/loader.rb
+++ b/lib/sidekiq/enqueuer/web_extension/loader.rb
@@ -36,7 +36,7 @@ module Sidekiq
               end
             end
 
-            redirect "/enqueuer"
+            redirect File.join(root_path, enqueuer)
           end
         end
         # rubocop:enable Metrics/MethodLength

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -2,12 +2,37 @@
 
 RSpec.describe Sidekiq::Enqueuer::Configuration do
   describe "#jobs" do
-    subject { config.available_jobs }
-
-    before { config.jobs = %w[NoParamWorker HardWorker] }
+    subject(:available_jobs) { config.available_jobs }
 
     let(:config) { described_class.new }
 
-    it { is_expected.to eq([HardWorker, NoParamWorker]) }
+    context "with provided jobs" do
+      before { config.jobs = %w[NoParamWorker HardWorker] }
+
+      it { is_expected.to eq([HardWorker, NoParamWorker]) }
+
+      context "with constants jobs" do
+        before { config.jobs = [NoParamWorker, HardWorker] }
+
+        it { is_expected.to eq([HardWorker, NoParamWorker]) }
+      end
+
+      context "with unsupported job class" do
+        before { config.jobs = [123, 321] }
+
+        it "raises corresponding error" do
+          expect { available_jobs }.to raise_error(described_class::UnsupportedJobType)
+        end
+      end
+    end
+
+    context "without provided jobs" do
+      it "queries active job and sidekiq jobs" do
+        expect(available_jobs).to match_array([
+          NoParamWorker, HardWorker, HardJob, WorkerWithPerformAsync, WorkerWithNoParams,
+          WorkerWithKeyValueParams, WorkerWithOptionalParams, WorkerWithDefinedQueue
+        ])
+      end
+    end
   end
 end

--- a/spec/setup_simplecov.rb
+++ b/spec/setup_simplecov.rb
@@ -7,7 +7,7 @@ SimpleCov.configure do
   enable_coverage :line
   enable_coverage :branch
 
-  minimum_coverage line: 94, branch: 65
+  minimum_coverage line: 95, branch: 75
 
   formatter SimpleCov::Formatter::MultiFormatter.new([
     SimpleCov::Formatter::HTMLFormatter,


### PR DESCRIPTION
+ Using `::Sidekiq::Enqueuer::Utils`
+ `require "sidekiq/enqueuer/utils"`
+ `Enqueue Form` => `Enqueue` just in case
+ Several specs for configuration
+ Use `ActiveJob::Base` descendants except `ApplicationJob` and `singleton_class?`
+ Fixed after enqueuing redirect path